### PR TITLE
fix: Simplify Groq tool_choice to String

### DIFF
--- a/lib/intelligence/adapters/groq.rb
+++ b/lib/intelligence/adapters/groq.rb
@@ -37,14 +37,7 @@ module Intelligence
 
           temperature         Float
           tool                array: true, as: :tools, &Tool.schema 
-          tool_choice do 
-            # one of 'auto', 'none' or 'function'
-            type              Symbol, in: [ :auto, :none, :function ]
-            # the function parameters is required if you specify a type of 'function' 
-            function do 
-              name            String 
-            end
-          end
+          tool_choice         String
         
           top_logprobs        Integer
           top_p               Float


### PR DESCRIPTION
I couldn't make Groq adapter tool choice work with current schema:

Currently it changes:

```
tool_choice: 'auto' 
```
to 
```
tool_choice: {}
```

So I receive this response

```
 Sending: POST http://api.groq.com:443/openai/v1/chat/completions
D, [2025-11-02T23:32:55.482715 #1278525] DEBUG -- : [httplog] Data: {"model":"openai/gpt-oss-20b","tool_choice":{},

[httplog] Response:
{"error":{"message":"'tool_choice' : value must be a string (auto or none) or an object like `{'type': 'function', 'function': {'name': 'my_function'}}`","type":"invalid_request_error"}}
```

I tried to pick up the OpenAI definition:

```ruby
          tool_choice               arguments: :type do 
            type                    Symbol, in: [ :none, :auto, :required ]
            function                arguments: :name do 
              name                  Symbol 
            end 
          end 
```

But it constructed object which again was not consumed by Groq API

```
"tool_choice":{"type":"auto"}
{"error":{"message":"'tool_choice' : value must be a string (auto or none) or an object like `{'type': 'function', 'function': {'name': 'my_function'}}`","type":"invalid_request_error"}}
```

I didn't find a way in dynamic schema to make it Sctring or Object so my proposed fix focuses on basic approaches:

- tool_choice: auto
- tool_choice: none
- 
@kristoph I saw you used Kimi K2 https://github.com/EndlessInternational/intelligence/commit/f7e8e8c18f339ba69a2f201c0e5f6459f3094b39 Can you also try it with a tool call (as it is agentic model)? 